### PR TITLE
Fixed blockquotes not appearing on whatismarkdown.com

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/FitText.js/1.1/jquery.fittext.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/pagedown/1.0/Markdown.Converter.js"></script>
     <script src="js/common.js"></script>
-    <script type="text/javascript">
+    <script type="text/javascript" async>
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-30235413-1']);
       _gaq.push(['_trackPageview']);

--- a/css/common.css
+++ b/css/common.css
@@ -1,6 +1,3 @@
-blockquote {
-  border: none;
-}
 h1,
 h2,
 h3,

--- a/js/common.js
+++ b/js/common.js
@@ -4,7 +4,7 @@
     var converter;
 
     converter = new Markdown.Converter();
-    $('.markdown').html(converter.makeHtml($('.markdown').html()));
+    $('.markdown').html(converter.makeHtml($('.markdown').text()));
     return $('.markdown-container').fadeIn({
       start: function() {
         return $("h1").fitText();


### PR DESCRIPTION
Have fixed the `common.js`, added an `async` tag to the GA script thereby slightly improving the load time.
Removed `blockquote` related styles from `common.css`, now it takes styles from bootstrap.
You can view the updated page [here](http://sahil290791.github.io/whatismarkdown.com/).
